### PR TITLE
Remove auto increment ids and fix tests

### DIFF
--- a/contracts/StanfordCS251NFT.sol
+++ b/contracts/StanfordCS251NFT.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.2;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
 
 /**
  * Created using Open Zeppelin contract wizard at
@@ -14,7 +13,6 @@ import "@openzeppelin/contracts/utils/Counters.sol";
  *
  * Rationale:
  * - Mintable: We want to mint new NFTs for each new class member
- * - Auto Increment Ids: Makes minting easier
  * - Enumerable: totalSupply() can be queried on-chain for convenience
  *     in exchange for extra gas cost on transfer. Since we want it
  *     to be non-transferable this is of no concern
@@ -23,26 +21,20 @@ import "@openzeppelin/contracts/utils/Counters.sol";
  *
  * Requirement: Non-transferable (see _beforeTokenTransfer override)
  */
-
 /// @custom:security-contact cs251ta@cs.stanford.edu
 contract CS251StanfordNFT is ERC721, ERC721Enumerable, AccessControl {
-  using Counters for Counters.Counter;
-
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-  Counters.Counter private _tokenIdCounter;
 
-  constructor() ERC721("CS251-Stanford-NFT", "CS251") {
+  constructor() ERC721("CS251 Stanford NFT", "CS251") {
     _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     _grantRole(MINTER_ROLE, msg.sender);
   }
 
   function _baseURI() internal pure override returns (string memory) {
-    return "https://<TBD>";
+    return "ipfs://";
   }
 
-  function safeMint(address to) public onlyRole(MINTER_ROLE) {
-    uint256 tokenId = _tokenIdCounter.current();
-    _tokenIdCounter.increment();
+  function safeMint(address to, uint256 tokenId) public onlyRole(MINTER_ROLE) {
     _safeMint(to, tokenId);
   }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,7 +11,7 @@ describe("CS251-Stanford-NFT", function () {
   this.beforeAll(async () => {
     [minter, account1, account2] = await ethers.getSigners();
   });
-  this.beforeAll(async () => {
+  beforeEach(async () => {
     const CS251StanfordNFTFactory = await ethers.getContractFactory(
       "CS251StanfordNFT"
     );
@@ -19,34 +19,39 @@ describe("CS251-Stanford-NFT", function () {
     await CS251StanfordNFT.deployed();
   });
   it("Should return the correct name", async function () {
-    expect(await CS251StanfordNFT.name()).to.equal("CS251-Stanford-NFT");
+    expect(await CS251StanfordNFT.name()).to.equal("CS251 Stanford NFT");
   });
   it("Should be mintable by minter", async function () {
-    const tx = await CS251StanfordNFT.safeMint(account1.address);
+    const tokenId = 42;
+    const tx = await CS251StanfordNFT.safeMint(account1.address, tokenId);
     await tx.wait();
     expect(await CS251StanfordNFT.totalSupply()).to.equal(1);
     expect(await CS251StanfordNFT.balanceOf(minter.address)).to.equal(0);
     expect(await CS251StanfordNFT.balanceOf(account1.address)).to.equal(1);
 
-    const tokenId = await CS251StanfordNFT.tokenOfOwnerByIndex(
+    const owner = await CS251StanfordNFT.ownerOf(tokenId);
+    expect(owner).to.equal(account1.address);
+
+    const retrievedTokenId = await CS251StanfordNFT.tokenOfOwnerByIndex(
       account1.address,
       0
     );
-    expect(tokenId).to.equal(0);
+    expect(retrievedTokenId).to.equal(tokenId);
   });
   it("Should not be mintable by non-minter", async function () {
     await expect(
-      CS251StanfordNFT.connect(account1).safeMint(account1.address)
+      CS251StanfordNFT.connect(account1).safeMint(account1.address, 42)
     ).to.be.revertedWith("");
   });
   it("Should not be transferable by non-minter", async function () {
-    const tx = await CS251StanfordNFT.safeMint(account1.address);
+    const tokenId = 42;
+    const tx = await CS251StanfordNFT.safeMint(account1.address, tokenId);
     await tx.wait();
-    const tokenId = await CS251StanfordNFT.tokenOfOwnerByIndex(
+    const retrievedTokenId = await CS251StanfordNFT.tokenOfOwnerByIndex(
       account1.address,
       0
     );
-    expect(tokenId).to.equal(0);
+    expect(retrievedTokenId).to.equal(tokenId);
     await expect(
       CS251StanfordNFT.connect(account1).transferFrom(
         account1.address,


### PR DESCRIPTION
No need for auto increment since tokenId will be IPFS hash of token metadata.